### PR TITLE
Work with peerDependencies

### DIFF
--- a/lib/nik.js
+++ b/lib/nik.js
@@ -76,11 +76,19 @@ var installToTmpDir = exports.installToTmpDir = function(pkg, callback) {
 
 
 /**
- * Get the single installed module in a directory.
+ * Get the single installed module in a directory.  The `npm install` command
+ * doesn't provide a deterministic way to get the name of the installed module.
+ * When a module has peer dependencies, multiple modules may be installed at
+ * once, and the names for all are returned (it seems the order has no meaning).
+ * So we have to scan through all installed modules and try to determine which
+ * one relates to the argument provided to `npm install` (in the case of a URL
+ * or file path, the module name may not be in the argument provided to the
+ * command).
  * @param {string} dir Path to directory.
  * @param {function(Error, string)} callback Called with an error if there are
- *     no installed modules or more than one installed module.  Called with the
- *     path to the installed module if there is one.
+ *     no installed modules or if the desired module cannot be identified.
+ *     The callback will be called with the path to the installed module if one
+ *     can be derived.
  */
 var getInstalledModule = exports.getInstalledModule = function(dir, callback) {
   var modules = path.join(dir, 'node_modules');
@@ -88,10 +96,29 @@ var getInstalledModule = exports.getInstalledModule = function(dir, callback) {
     if (err) {
       return callback(err);
     }
-    if (files.length !== 1) {
-      return callback(new Error('Expected a single module in ' + modules));
+    if (files.length === 1) {
+      return callback(null, path.join(modules, files[0]));
+    } else {
+      var deps = {};
+      try {
+        files.forEach(function(filepath) {
+          var pkg = require(path.join(modules, filepath, 'package.json'));
+          if (pkg.peerDependencies) {
+            assign(deps, pkg.peerDependencies);
+          }
+        });
+      } catch (e) {
+        callback(new Error('Failed to get installed module: ' + e.message));
+      }
+      var candidates = files.filter(function(filepath) {
+        return !deps.hasOwnProperty(filepath);
+      });
+      if (candidates.length === 1) {
+        callback(null, path.join(modules, candidates[0]));
+      } else {
+        callback(new Error('Could not resolve installed module: ' + dir));
+      }
     }
-    callback(null, path.join(modules, files[0]));
   });
 };
 


### PR DESCRIPTION
The `getInstalledModule` function fails when the target package has `peerDependencies`.
