### PR TITLE
Limit package properties that are copied

### DIFF
--- a/lib/nik.js
+++ b/lib/nik.js
@@ -152,7 +152,8 @@ var overwritePackageConfig = exports.overwritePackageConfig =
     function(manifest, overrides, callback) {
   var config = assign(require(manifest), overrides);
   var ignores = [
-    'homepage', 'repository', 'readme', 'readmeFilename', 'bugs', '_id', '_from'
+    'bugs', 'dist', 'homepage', 'readme', 'readmeFilename', 'repository',
+    '_from', '_fromGithub', '_id', '_resolved'
   ];
   ignores.forEach(function(ignore) {
     delete config[ignore];


### PR DESCRIPTION
The following properties (and likely more) should not be copied:
- _id
- _resolved
- _from
- _fromGithub
- dist
- readme
- readmeFilename
